### PR TITLE
Fix error in senior section

### DIFF
--- a/stadgar.md
+++ b/stadgar.md
@@ -63,7 +63,7 @@ Seniormedlemmar äger följande rättigheter:
 
 Seniormedlemmar har följande skyldighet:
 
-* att betala en engångsavgift årsavgift, vars storlek fastställs på medlemsmöte föreningens vårmöte
+* att betala en årsavgift, vars storlek fastställs på föreningens vårmöte
 
 **§ 5 Hedersmedlemmar**
 


### PR DESCRIPTION
Fix typos i `seniormedlem` paragrafen som kom under stadga migration ti Github 